### PR TITLE
Issue 2: Cache downloaded schemas

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,8 +1,9 @@
-name: Publish NPM Package
+name: Build and publish NPM package
 
 on:
   release:
     types: [created]
+  pull_request:
   push:
     tags:
       - 'v*'
@@ -42,4 +43,5 @@ jobs:
         run: npm run build
 
       - name: Publish to NPM
+        if: ${{ github.ref_type == 'tag' }}
         run: npm publish --access public

--- a/index.html
+++ b/index.html
@@ -93,6 +93,7 @@
       const resultDiv = document.getElementById("result");
 
       validateBtn.addEventListener("click", async () => {
+        performance.mark("start-validation");
         try {
           const schemaURL = schemaInput.value;
           const data = JSON.parse(dataInput.value);
@@ -107,6 +108,8 @@
           resultDiv.className = "error";
           resultDiv.textContent = `Error: ${error.message}`;
         }
+        const perfData = performance.measure("validation-length", "start-validation");
+        console.log(`Schema validation takes ${perfData.duration.toFixed(2)} ms`);
       });
     </script>
   </body>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lsolova/json-schema-validator",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "JSON schema validator (with Rust WASM based on jsonschema)",
   "repository": {
     "type": "git",

--- a/readme.md
+++ b/readme.md
@@ -1,7 +1,6 @@
 # JSON schema validator
 
-This experimental project is to provide a secure JSON schema validation in browser environment. It uses _jsonschema_
-Rust package wrapped into a WASM module and exposing functionality within SchemaValidator object.
+This experimental project provides a secure JSON schema validation in browser environment. It uses _jsonschema_ Rust package wrapped into a WASM module and exposing functionality within SchemaValidator object.
 
 ## Usage
 
@@ -11,17 +10,52 @@ Copy the following file into your output:
 |-----------|------------------------------------------------------------------|
 | wasmURL   | @lsolova/json-schema-validator/dist/assets/schema_validator.wasm |
 
+First it must be initialized by passing the deployed WASM file URL.
+
+Then a simple validate can be used, by passing the URL of the schema file (http:// or https:// protocols are accepted) and the data to be validated. If a schema is downloaded, then it is cached until the session exists.
+
 ```ts
 import { SchemaValidator } from "@lsolova/json-schema-validator";
 
 async function initValidation {
-    // Set the wasmURL to the URL of the copied WASM file (without origin)
+    // Set the wasmURL to the URL of the exposed WASM file (see more details below)
     await SchemaValidator.init(wasmURL);
 };
 
 async function validate(schemaURL, data) {
     await SchemaValidator.validate(schemaURL, data);
 };
+```
+
+This validator supports HTTP/HTTPS references within the schema files (see `$ref`).
+
+```json
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+        "name": {"type": "string"},
+        "email": {"$ref": "http://example.com/schemas/email.schema.json"}
+    },
+    "required": ["name", "email"]
+}
+```
+
+### How to add WASM file to your deployment?
+
+#### Using esbuild
+
+TBD
+
+#### Using Vite
+
+Please, use the [explicit URL import](https://vite.dev/guide/assets#explicit-url-imports) feature of Vite passing WASM URL to the _SchemaValidator.init_ function. Everything else will be managed by Vite build.
+
+```ts
+import { SchemaValidator } from "@lsolova/json-schema-validator";
+import wasmURL from "@lsolova/json-schema-validator/dist/assets/schema_validator.wasm?url";
+
+SchemaValidator.init(wasmURL);
 ```
 
 ## Development

--- a/script/src/schema-validator.ts
+++ b/script/src/schema-validator.ts
@@ -1,26 +1,25 @@
-import init, { validate } from "../wasm/schema_validator.js";
+import wasmInit, { WasmSchemaValidator } from "../wasm/schema_validator.js";
 import { WasmStatus, WasmStatusSet } from "./types.js";
-
-
-
 
 export class SchemaValidator {
     private _wasmStatus: WasmStatus = WasmStatusSet.UNINITIALIZED;
+    private _schemaValidator: WasmSchemaValidator | null = null;
 
     async init(wasmURL: string): Promise<void> {
         if (this._wasmStatus === WasmStatusSet.UNINITIALIZED || this._wasmStatus === WasmStatusSet.FAILED) {
             try {
-                await init(wasmURL);
+                await wasmInit(wasmURL);
+                this._schemaValidator = new WasmSchemaValidator();
                 this._wasmStatus = WasmStatusSet.READY;
             } catch (error) {
                 this._wasmStatus = WasmStatusSet.FAILED;
-                throw new Error("WASM initialization failed.");
+                throw new Error(`WASM initialization failed. ${JSON.stringify(error)}`);
             }
         }
     }
 
     async validate(schemaURL: string, data: object): Promise<boolean> {
-        if (this._wasmStatus !== WasmStatusSet.READY) {
+        if (this._wasmStatus !== WasmStatusSet.READY || this._schemaValidator === null) {
             throw new Error("WASM is not initialized. Call init() first.");
         }
         if (!schemaURL.startsWith("http://") && !schemaURL.startsWith("https://")) {
@@ -29,7 +28,7 @@ export class SchemaValidator {
         try {
             let schema = JSON.stringify({ "$ref": schemaURL });
             let dataString = JSON.stringify(data);
-            const isValid = await validate(schema, dataString);
+            const isValid = await this._schemaValidator.validate(schema, dataString);
             return isValid;
         } catch (error) {
             throw error instanceof Error ? error.message : new Error(JSON.stringify(error));

--- a/wasm/Cargo.lock
+++ b/wasm/Cargo.lock
@@ -56,9 +56,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.15.2"
+version = "1.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a88aab2464f1f25453baa7a07c84c5b7684e274054ba06817f382357f77a288"
+checksum = "e84ce723ab67259cfeb9877c6a639ee9eb7a27b28123abd71db7f0d5d0cc9d86"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -66,9 +66,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.35.0"
+version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b45afffdee1e7c9126814751f88dddc747f41d91da16c9551a0f1e8a11e788a1"
+checksum = "43a442ece363113bd4bd4c8b18977a7798dd4d3c3383f34fb61936960e8f4ad8"
 dependencies = [
  "cc",
  "cmake",
@@ -129,9 +129,9 @@ checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
 
 [[package]]
 name = "cc"
-version = "1.2.51"
+version = "1.2.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a0aeaff4ff1a90589618835a598e545176939b97874f7abc7851caa0618f203"
+checksum = "cd4932aefd12402b36c60956a4fe0035421f544799057659ff86f923657aada3"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -204,9 +204,9 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "data-encoding"
-version = "2.9.0"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a2330da5de22e8a3cb63252ce2abb30116bf5265e89c0e01bc17015ce30a476"
+checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
 
 [[package]]
 name = "displaydoc"
@@ -278,9 +278,9 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "645cbb3a84e60b7531617d5ae4e57f7e27308f6445f5abf653209ea76dec8dff"
+checksum = "f449e6c6c08c865631d4890cfacf252b3d396c9bcc83adb6623cdb02a8336c41"
 
 [[package]]
 name = "fluent-uri"
@@ -436,9 +436,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -778,9 +778,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.83"
+version = "0.3.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "464a3709c7f55f1f721e5389aa6ea4e3bc6aba669353300af094b29ffbdde1d8"
+checksum = "8c942ebf8e95485ca0d52d97da7c5a2c387d0e7f0ba4c35e93bfcaee045955b3"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -1209,9 +1209,9 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.9.3"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
 ]
@@ -1381,7 +1381,7 @@ checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
 dependencies = [
  "cc",
  "cfg-if",
- "getrandom 0.2.16",
+ "getrandom 0.2.17",
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
@@ -1864,9 +1864,9 @@ dependencies = [
 
 [[package]]
 name = "tower"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
 dependencies = [
  "futures-core",
  "futures-util",
@@ -2032,9 +2032,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.106"
+version = "0.2.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d759f433fa64a2d763d1340820e46e111a7a5ab75f993d1852d70b03dbb80fd"
+checksum = "64024a30ec1e37399cf85a7ffefebdb72205ca1c972291c51512360d90bd8566"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -2045,11 +2045,12 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.56"
+version = "0.4.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "836d9622d604feee9e5de25ac10e3ea5f2d65b41eac0d9ce72eb5deae707ce7c"
+checksum = "70a6e77fd0ae8029c9ea0063f87c46fde723e7d887703d74ad2616d792e51e6f"
 dependencies = [
  "cfg-if",
+ "futures-util",
  "js-sys",
  "once_cell",
  "wasm-bindgen",
@@ -2058,9 +2059,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.106"
+version = "0.2.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48cb0d2638f8baedbc542ed444afc0644a29166f1595371af4fecf8ce1e7eeb3"
+checksum = "008b239d9c740232e71bd39e8ef6429d27097518b6b30bdf9086833bd5b6d608"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2068,9 +2069,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.106"
+version = "0.2.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cefb59d5cd5f92d9dcf80e4683949f15ca4b511f4ac0a6e14d4e1ac60c6ecd40"
+checksum = "5256bae2d58f54820e6490f9839c49780dff84c65aeab9e772f15d5f0e913a55"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -2081,18 +2082,18 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.106"
+version = "0.2.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbc538057e648b67f72a982e708d485b2efa771e1ac05fec311f9f63e5800db4"
+checksum = "1f01b580c9ac74c8d8f0c0e4afb04eeef2acf145458e52c03845ee9cd23e3d12"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "web-sys"
-version = "0.3.83"
+version = "0.3.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b32828d774c412041098d182a8b38b16ea816958e07cf40eec2bc080ae137ac"
+checksum = "312e32e551d92129218ea9a2452120f4aabc03529ef03e4d0d82fb2780608598"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2500,6 +2501,6 @@ dependencies = [
 
 [[package]]
 name = "zmij"
-version = "1.0.12"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fc5a66a20078bf1251bde995aa2fdcc4b800c70b5d92dd2c62abc5c60f679f8"
+checksum = "bd8f3f50b848df28f887acb68e41201b5aea6bc8a8dacc00fb40635ff9a72fea"

--- a/wasm/src/schema_retriever.rs
+++ b/wasm/src/schema_retriever.rs
@@ -1,0 +1,34 @@
+use crate::schema_store::SchemaStore;
+use jsonschema::{AsyncRetrieve, Uri};
+use serde_json::Value;
+use std::sync::Arc;
+
+pub struct SchemaRetriever {
+    schema_store: Arc<SchemaStore>,
+}
+
+impl SchemaRetriever {
+    pub fn new(schema_store: Arc<SchemaStore>) -> Self {
+        SchemaRetriever { schema_store }
+    }
+}
+
+#[cfg_attr(target_family = "wasm", async_trait::async_trait(?Send))]
+#[cfg_attr(not(target_family = "wasm"), async_trait::async_trait)]
+impl AsyncRetrieve for SchemaRetriever {
+    async fn retrieve(
+        &self,
+        uri: &Uri<String>,
+    ) -> Result<Value, Box<dyn std::error::Error + Send + Sync>> {
+        let url = uri.as_str();
+
+        if url.starts_with("http://") || url.starts_with("https://") {
+            match self.schema_store.retrieve(url.to_string()).await {
+                Ok(schema) => Ok(schema),
+                Err(e) => Err(Into::into(e)),
+            }
+        } else {
+            Err("Schema URI's protocol not supported. Check the passed URI.".into())
+        }
+    }
+}

--- a/wasm/src/schema_store.rs
+++ b/wasm/src/schema_store.rs
@@ -1,0 +1,74 @@
+use reqwest::{get, Response};
+use serde_json::Value;
+use std::{collections::HashMap, error::Error, sync::Mutex};
+
+pub struct SchemaStore {
+    schema_store: Mutex<HashMap<String, Value>>,
+}
+
+impl SchemaStore {
+    pub fn new() -> Self {
+        SchemaStore {
+            schema_store: Mutex::new(HashMap::new()),
+        }
+    }
+
+    async fn retrieve_via_http(
+        &self,
+        url: &str,
+    ) -> Result<Value, Box<dyn Error + Send + Sync>> {
+        let resp: Response = get(url).await?;
+        match resp.json::<Value>().await {
+            Ok(schema) => Ok(schema),
+            Err(e) => Err(Into::into(e)),
+        }
+    }
+
+    pub async fn add(
+        &self,
+        id: &String,
+        content: &Value,
+    ) -> Result<(), Box<dyn Error + Send + Sync>> {
+        let Ok(mut guard) = self.schema_store.lock() else {
+            return Err("Schema store is not available (poisoned).".into());
+        };
+        guard.insert(id.clone(), content.clone());
+        Ok(())
+    }
+
+    pub async fn get(&self, id: &String) -> Result<Option<Value>, Box<dyn Error + Send + Sync>> {
+        let Ok(guard) = self.schema_store.lock() else {
+            return Err("Schema store is not available (poisoned).".into());
+        };
+        match guard.get(id) {
+            Some(s) => Ok(Some(s.clone())),
+            None => Ok(None),
+        }
+    }
+
+    pub async fn retrieve(&self, id: String) -> Result<Value, Box<dyn Error + Send + Sync>> {
+        let schema = match self.get(&id).await {
+            Ok(s) => s,
+            Err(e) => {
+                return Err(e);
+            }
+        };
+
+        match schema {
+            Some(schema) => Ok(schema),
+            None => {
+                if id.starts_with("http://") || id.starts_with("https://") {
+                    match self.retrieve_via_http(&id).await {
+                        Ok(schema) => {
+                            let _ = self.add(&id, &schema).await;
+                            Ok(schema)
+                        }
+                        Err(e) => Err(e),
+                    }
+                } else {
+                    Err("Schema protocol is invalid. Only HTTP(S) can be resolved, if it is not in the schema store.".into())
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
- Expose new WasmSchemaValidator struct (constructor + validate function)
- HttpRetriever is changed to SchemaRetriever
- Add new SchemaStore struct to handle cached/saved schemas and retrieve HTTP(S) schemas if they are not cached yet
- Documentation
- Cargo update